### PR TITLE
upgrade gulp to 4.0.0

### DIFF
--- a/examples/browserify/gulpfile.js
+++ b/examples/browserify/gulpfile.js
@@ -31,4 +31,4 @@ gulp.task('build-worker', function() {
     .pipe(gulp.dest(OUTPUT_PATH));
 });
 
-gulp.task('build', ['build-bundle', 'build-worker']);
+gulp.task('build', gulp.series('build-bundle', 'build-worker'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,7 +118,7 @@ function safeSpawnSync(command, parameters, options) {
   var result = spawnSync(command, parameters, options);
   if (result.status !== 0) {
     console.log('Error: command "' + command + '" with parameters "' +
-                parameters + '" exited with code ' + result.status);
+      parameters + '" exited with code ' + result.status);
     process.exit(result.status);
   }
   return result;
@@ -148,9 +148,9 @@ function createWebpackConfig(defines, output) {
   var licenseHeaderLibre =
     fs.readFileSync('./src/license_header_libre.js').toString();
   var enableSourceMaps = !bundleDefines.FIREFOX && !bundleDefines.MOZCENTRAL &&
-                         !bundleDefines.CHROME;
+    !bundleDefines.CHROME;
   var skipBabel = bundleDefines.SKIP_BABEL ||
-                  process.env['SKIP_BABEL'] === 'true';
+    process.env['SKIP_BABEL'] === 'true';
 
   // Required to expose e.g., the `window` object.
   output.globalObject = 'this';
@@ -250,7 +250,7 @@ function checkChromePreferencesFile(chromePrefsPath, webPrefsPath) {
   }
   return webPrefsKeys.every(function (value, index) {
     return chromePrefsKeys[index] === value &&
-           chromePrefs.properties[value].default === webPrefs[value];
+      chromePrefs.properties[value].default === webPrefs[value];
   });
 }
 
@@ -263,7 +263,7 @@ function replaceWebpackRequire() {
 function replaceJSRootName(amdName, jsName) {
   // Saving old-style JS module name.
   return replace('root["' + amdName + '"] = factory()',
-                 'root["' + amdName + '"] = root.' + jsName + ' = factory()');
+    'root["' + amdName + '"] = root.' + jsName + ' = factory()');
 }
 
 function createBundle(defines) {
@@ -308,7 +308,7 @@ function createWebBundle(defines) {
     filename: viewerOutputName,
   });
   return gulp.src('./web/viewer.js')
-             .pipe(webpack2Stream(viewerFileConfig));
+    .pipe(webpack2Stream(viewerFileConfig));
 }
 
 function createComponentsBundle(defines) {
@@ -387,9 +387,9 @@ function createTestSource(testsName, bot) {
 
     if (!checkFile('test/' + PDF_BROWSERS)) {
       console.log('Browser manifest file test/' + PDF_BROWSERS +
-                  ' does not exist.');
+        ' does not exist.');
       console.log('Copy and adjust the example in ' +
-                  'test/resources/browser_manifests.');
+        'test/resources/browser_manifests.');
       this.emit('error', new Error('Missing manifest file'));
       return null;
     }
@@ -452,13 +452,14 @@ function makeRef(done, bot) {
   });
 }
 
-gulp.task('default', function() {
+gulp.task('default', function(done) {
   console.log('Available tasks:');
-  var tasks = Object.keys(gulp.tasks);
+  var tasks = Object.keys(gulp.registry().tasks());
   tasks.sort();
   tasks.forEach(function (taskName) {
     console.log('  ' + taskName);
   });
+  done();
 });
 
 gulp.task('buildnumber', function (done) {
@@ -466,34 +467,34 @@ gulp.task('buildnumber', function (done) {
   console.log('### Getting extension build number');
 
   exec('git log --format=oneline ' + config.baseVersion + '..',
-      function (err, stdout, stderr) {
-    var buildNumber = 0;
-    if (!err) {
-      // Build number is the number of commits since base version
-      buildNumber = stdout ? stdout.match(/\n/g).length : 0;
-    } else {
-      console.log('This is not a Git repository; using default build number.');
-    }
-
-    console.log('Extension build number: ' + buildNumber);
-
-    var version = config.versionPrefix + buildNumber;
-
-    exec('git log --format="%h" -n 1', function (err, stdout, stderr) {
-      var buildCommit = '';
+    function (err, stdout, stderr) {
+      var buildNumber = 0;
       if (!err) {
-        buildCommit = stdout.replace('\n', '');
+        // Build number is the number of commits since base version
+        buildNumber = stdout ? stdout.match(/\n/g).length : 0;
+      } else {
+        console.log('This is not a Git repository; using default build number.');
       }
 
-      createStringSource('version.json', JSON.stringify({
-        version: version,
-        build: buildNumber,
-        commit: buildCommit,
-      }, null, 2))
-        .pipe(gulp.dest(BUILD_DIR))
-        .on('end', done);
+      console.log('Extension build number: ' + buildNumber);
+
+      var version = config.versionPrefix + buildNumber;
+
+      exec('git log --format="%h" -n 1', function (err, stdout, stderr) {
+        var buildCommit = '';
+        if (!err) {
+          buildCommit = stdout.replace('\n', '');
+        }
+
+        createStringSource('version.json', JSON.stringify({
+          version: version,
+          build: buildNumber,
+          commit: buildCommit,
+        }, null, 2))
+          .pipe(gulp.dest(BUILD_DIR))
+          .on('end', done);
+      });
     });
-  });
 });
 
 gulp.task('locale', function () {
@@ -532,11 +533,11 @@ gulp.task('locale', function () {
     locales.push(locale);
 
     chromeManifestContent += 'locale  pdf.js  ' + locale + '  locale/' +
-                             locale + '/\n';
+      locale + '/\n';
 
     if (checkFile(path + '/viewer.properties')) {
       viewerOutput += '[' + locale + ']\n' +
-                      '@import url(' + locale + '/viewer.properties)\n\n';
+        '@import url(' + locale + '/viewer.properties)\n\n';
     }
 
     if (checkFile(path + '/metadata.inc')) {
@@ -551,18 +552,18 @@ gulp.task('locale', function () {
     createStringSource('chrome.manifest.inc', chromeManifestContent)
       .pipe(gulp.dest(METADATA_OUTPUT)),
     gulp.src(L10N_DIR + '/{' + locales.join(',') + '}' +
-             '/{viewer,chrome}.properties', { base: L10N_DIR, })
+      '/{viewer,chrome}.properties', { base: L10N_DIR, })
       .pipe(gulp.dest(EXTENSION_LOCALE_OUTPUT)),
 
     createStringSource('locale.properties', viewerOutput)
       .pipe(gulp.dest(VIEWER_LOCALE_OUTPUT)),
     gulp.src(L10N_DIR + '/{' + locales.join(',') + '}' +
-             '/viewer.properties', { base: L10N_DIR, })
+      '/viewer.properties', { base: L10N_DIR, })
       .pipe(gulp.dest(VIEWER_LOCALE_OUTPUT))
   ]);
 });
 
-gulp.task('cmaps', function () {
+gulp.task('cmaps', function (done) {
   var CMAP_INPUT = 'external/cmaps';
   var VIEWER_CMAP_OUTPUT = 'external/bcmaps';
 
@@ -586,11 +587,12 @@ gulp.task('cmaps', function () {
   var compressCmaps =
     require('./external/cmapscompress/compress.js').compressCmaps;
   compressCmaps(CMAP_INPUT, VIEWER_CMAP_OUTPUT, true);
+  done();
 });
 
-gulp.task('bundle', ['buildnumber'], function () {
+gulp.task('bundle', gulp.series('buildnumber', function () {
   return createBundle(DEFINES).pipe(gulp.dest(BUILD_DIR));
-});
+}));
 
 function preprocessCSS(source, mode, defines, cleanup) {
   var outName = getTempFile('~preprocess', '.css');
@@ -619,7 +621,7 @@ function preprocessHTML(source, defines) {
 
 // Builds the generic production viewer that should be compatible with most
 // modern HTML5 browsers.
-gulp.task('generic', ['buildnumber', 'locale'], function () {
+gulp.task('generic', gulp.series('buildnumber', 'locale', function () {
   console.log();
   console.log('### Creating generic viewer');
   var defines = builder.merge(DEFINES, { GENERIC: true, });
@@ -630,25 +632,25 @@ gulp.task('generic', ['buildnumber', 'locale'], function () {
     createBundle(defines).pipe(gulp.dest(GENERIC_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(GENERIC_DIR + 'web')),
     gulp.src(COMMON_WEB_FILES, { base: 'web/', })
-        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+      .pipe(gulp.dest(GENERIC_DIR + 'web')),
     gulp.src('LICENSE').pipe(gulp.dest(GENERIC_DIR)),
     gulp.src([
       'web/locale/*/viewer.properties',
       'web/locale/locale.properties'
     ], { base: 'web/', }).pipe(gulp.dest(GENERIC_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             { base: 'external/bcmaps', })
-        .pipe(gulp.dest(GENERIC_DIR + 'web/cmaps')),
+      { base: 'external/bcmaps', })
+      .pipe(gulp.dest(GENERIC_DIR + 'web/cmaps')),
     preprocessHTML('web/viewer.html', defines)
-        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+      .pipe(gulp.dest(GENERIC_DIR + 'web')),
     preprocessCSS('web/viewer.css', 'generic', defines, true)
-        .pipe(postcss([autoprefixer(AUTOPREFIXER_CONFIG)]))
-        .pipe(gulp.dest(GENERIC_DIR + 'web')),
+      .pipe(postcss([autoprefixer(AUTOPREFIXER_CONFIG)]))
+      .pipe(gulp.dest(GENERIC_DIR + 'web')),
 
   ]);
-});
+}));
 
-gulp.task('components', ['buildnumber'], function () {
+gulp.task('components', gulp.series('buildnumber', function () {
   console.log();
   console.log('### Creating generic components');
   var defines = builder.merge(DEFINES, { COMPONENTS: true, GENERIC: true, });
@@ -666,21 +668,21 @@ gulp.task('components', ['buildnumber'], function () {
     createComponentsBundle(defines).pipe(gulp.dest(COMPONENTS_DIR)),
     gulp.src(COMPONENTS_IMAGES).pipe(gulp.dest(COMPONENTS_DIR + 'images')),
     preprocessCSS('web/pdf_viewer.css', 'components', defines, true)
-        .pipe(postcss([autoprefixer(AUTOPREFIXER_CONFIG)]))
-        .pipe(gulp.dest(COMPONENTS_DIR)),
+      .pipe(postcss([autoprefixer(AUTOPREFIXER_CONFIG)]))
+      .pipe(gulp.dest(COMPONENTS_DIR)),
   ]);
-});
+}));
 
-gulp.task('image_decoders', ['buildnumber'], function() {
+gulp.task('image_decoders', gulp.series('buildnumber', function() {
   console.log();
   console.log('### Creating image decoders');
   var defines = builder.merge(DEFINES, { GENERIC: true,
-                                         IMAGE_DECODERS: true, });
+    IMAGE_DECODERS: true, });
 
   return createImageDecodersBundle(defines).pipe(gulp.dest(IMAGE_DECODERS_DIR));
-});
+}));
 
-gulp.task('minified-pre', ['buildnumber', 'locale'], function () {
+gulp.task('minified-pre', gulp.series('buildnumber', 'locale', function () {
   console.log();
   console.log('### Creating minified viewer');
   var defines = builder.merge(DEFINES, { MINIFIED: true, GENERIC: true, });
@@ -691,27 +693,27 @@ gulp.task('minified-pre', ['buildnumber', 'locale'], function () {
     createBundle(defines).pipe(gulp.dest(MINIFIED_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(MINIFIED_DIR + 'web')),
     createImageDecodersBundle(builder.merge(defines, { IMAGE_DECODERS: true, }))
-        .pipe(gulp.dest(MINIFIED_DIR + 'image_decoders')),
+      .pipe(gulp.dest(MINIFIED_DIR + 'image_decoders')),
     gulp.src(COMMON_WEB_FILES, { base: 'web/', })
-        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+      .pipe(gulp.dest(MINIFIED_DIR + 'web')),
     gulp.src([
       'web/locale/*/viewer.properties',
       'web/locale/locale.properties'
     ], { base: 'web/', }).pipe(gulp.dest(MINIFIED_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             { base: 'external/bcmaps', })
-        .pipe(gulp.dest(MINIFIED_DIR + 'web/cmaps')),
+      { base: 'external/bcmaps', })
+      .pipe(gulp.dest(MINIFIED_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
-        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+      .pipe(gulp.dest(MINIFIED_DIR + 'web')),
     preprocessCSS('web/viewer.css', 'minified', defines, true)
-        .pipe(postcss([autoprefixer(AUTOPREFIXER_CONFIG)]))
-        .pipe(gulp.dest(MINIFIED_DIR + 'web')),
+      .pipe(postcss([autoprefixer(AUTOPREFIXER_CONFIG)]))
+      .pipe(gulp.dest(MINIFIED_DIR + 'web')),
 
   ]);
-});
+}));
 
-gulp.task('minified-post', ['minified-pre'], function () {
+gulp.task('minified-post', gulp.series('minified-pre', function () {
   var pdfFile = fs.readFileSync(MINIFIED_DIR + '/build/pdf.js').toString();
   var pdfWorkerFile =
     fs.readFileSync(MINIFIED_DIR + '/build/pdf.worker.js').toString();
@@ -730,13 +732,13 @@ gulp.task('minified-post', ['minified-pre'], function () {
   var optsForHugeFile = { compress: { sequences: false, }, };
 
   fs.writeFileSync(MINIFIED_DIR + '/web/pdf.viewer.js',
-                   UglifyES.minify(viewerFiles).code);
+    UglifyES.minify(viewerFiles).code);
   fs.writeFileSync(MINIFIED_DIR + '/build/pdf.min.js',
-                   UglifyES.minify(pdfFile).code);
+    UglifyES.minify(pdfFile).code);
   fs.writeFileSync(MINIFIED_DIR + '/build/pdf.worker.min.js',
-                   UglifyES.minify(pdfWorkerFile, optsForHugeFile).code);
+    UglifyES.minify(pdfWorkerFile, optsForHugeFile).code);
   fs.writeFileSync(MINIFIED_DIR + 'image_decoders/pdf.image_decoders.min.js',
-                   UglifyES.minify(pdfImageDecodersFile).code);
+    UglifyES.minify(pdfImageDecodersFile).code);
 
   console.log();
   console.log('### Cleaning js files');
@@ -746,14 +748,14 @@ gulp.task('minified-post', ['minified-pre'], function () {
   fs.unlinkSync(MINIFIED_DIR + '/build/pdf.js');
   fs.unlinkSync(MINIFIED_DIR + '/build/pdf.worker.js');
   fs.renameSync(MINIFIED_DIR + '/build/pdf.min.js',
-                MINIFIED_DIR + '/build/pdf.js');
+    MINIFIED_DIR + '/build/pdf.js');
   fs.renameSync(MINIFIED_DIR + '/build/pdf.worker.min.js',
-                MINIFIED_DIR + '/build/pdf.worker.js');
+    MINIFIED_DIR + '/build/pdf.worker.js');
   fs.renameSync(MINIFIED_DIR + '/image_decoders/pdf.image_decoders.min.js',
-                MINIFIED_DIR + '/image_decoders/pdf.image_decoders.js');
-});
+    MINIFIED_DIR + '/image_decoders/pdf.image_decoders.js');
+}));
 
-gulp.task('minified', ['minified-post']);
+gulp.task('minified', gulp.series('minified-post'));
 
 function preprocessDefaultPreferences(content) {
   var preprocessor2 = require('./external/builder/preprocessor2.js');
@@ -769,20 +771,20 @@ function preprocessDefaultPreferences(content) {
   }, content);
 
   return (licenseHeader + '\n' + GLOBALS + '\n' + MODIFICATION_WARNING + '\n' +
-          content + '\n');
+    content + '\n');
 }
 
-gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
+gulp.task('mozcentral-pre', gulp.series('buildnumber', 'locale', function () {
   console.log();
   console.log('### Building mozilla-central extension');
   var defines = builder.merge(DEFINES, { MOZCENTRAL: true, SKIP_BABEL: true, });
 
   var MOZCENTRAL_DIR = BUILD_DIR + 'mozcentral/',
-      MOZCENTRAL_EXTENSION_DIR = MOZCENTRAL_DIR + 'browser/extensions/pdfjs/',
-      MOZCENTRAL_CONTENT_DIR = MOZCENTRAL_EXTENSION_DIR + 'content/',
-      FIREFOX_EXTENSION_DIR = 'extensions/firefox/',
-      MOZCENTRAL_L10N_DIR = MOZCENTRAL_DIR + 'browser/locales/en-US/pdfviewer/',
-      FIREFOX_CONTENT_DIR = EXTENSION_SRC_DIR + '/firefox/content/';
+    MOZCENTRAL_EXTENSION_DIR = MOZCENTRAL_DIR + 'browser/extensions/pdfjs/',
+    MOZCENTRAL_CONTENT_DIR = MOZCENTRAL_EXTENSION_DIR + 'content/',
+    FIREFOX_EXTENSION_DIR = 'extensions/firefox/',
+    MOZCENTRAL_L10N_DIR = MOZCENTRAL_DIR + 'browser/locales/en-US/pdfviewer/',
+    FIREFOX_CONTENT_DIR = EXTENSION_SRC_DIR + '/firefox/content/';
 
   // Clear out everything in the firefox extension build directory
   rimraf.sync(MOZCENTRAL_DIR);
@@ -794,41 +796,41 @@ gulp.task('mozcentral-pre', ['buildnumber', 'locale'], function () {
     createBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
     gulp.src(COMMON_WEB_FILES, { base: 'web/', })
-        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+      .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             { base: 'external/bcmaps', })
-        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web/cmaps')),
+      { base: 'external/bcmaps', })
+      .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
-        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+      .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
     preprocessCSS('web/viewer.css', 'mozcentral', defines, true)
-        .pipe(postcss([
-            autoprefixer({ browsers: ['last 1 firefox versions'], })
-        ]))
-        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
+      .pipe(postcss([
+        autoprefixer({ browsers: ['last 1 firefox versions'], })
+      ]))
+      .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR + 'web')),
 
     gulp.src(FIREFOX_EXTENSION_DIR + 'locale/en-US/*.properties')
-        .pipe(gulp.dest(MOZCENTRAL_L10N_DIR)),
+      .pipe(gulp.dest(MOZCENTRAL_L10N_DIR)),
     gulp.src(FIREFOX_EXTENSION_DIR + 'README.mozilla')
-        .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))
-        .pipe(replace(/\bPDFJSSCRIPT_COMMIT\b/g, commit))
-        .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
+      .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))
+      .pipe(replace(/\bPDFJSSCRIPT_COMMIT\b/g, commit))
+      .pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
     gulp.src('LICENSE').pipe(gulp.dest(MOZCENTRAL_EXTENSION_DIR)),
     gulp.src(FIREFOX_CONTENT_DIR + 'PdfJsDefaultPreferences.jsm')
-        .pipe(transform('utf8', preprocessDefaultPreferences))
-        .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
+      .pipe(transform('utf8', preprocessDefaultPreferences))
+      .pipe(gulp.dest(MOZCENTRAL_CONTENT_DIR)),
   ]);
-});
+}));
 
-gulp.task('mozcentral', ['mozcentral-pre']);
+gulp.task('mozcentral', gulp.series('mozcentral-pre'));
 
-gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
+gulp.task('chromium-pre', gulp.series('buildnumber', 'locale', function () {
   console.log();
   console.log('### Building Chromium extension');
   var defines = builder.merge(DEFINES, { CHROME: true, });
 
   var CHROME_BUILD_DIR = BUILD_DIR + '/chromium/',
-      CHROME_BUILD_CONTENT_DIR = CHROME_BUILD_DIR + '/content/';
+    CHROME_BUILD_CONTENT_DIR = CHROME_BUILD_DIR + '/content/';
 
   // Clear out everything in the chrome extension build directory
   rimraf.sync(CHROME_BUILD_DIR);
@@ -839,35 +841,35 @@ gulp.task('chromium-pre', ['buildnumber', 'locale'], function () {
     createBundle(defines).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'build')),
     createWebBundle(defines).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
     gulp.src(COMMON_WEB_FILES, { base: 'web/', })
-        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+      .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
 
     gulp.src([
       'web/locale/*/viewer.properties',
       'web/locale/locale.properties'
     ], { base: 'web/', }).pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
     gulp.src(['external/bcmaps/*.bcmap', 'external/bcmaps/LICENSE'],
-             { base: 'external/bcmaps', })
-        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web/cmaps')),
+      { base: 'external/bcmaps', })
+      .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web/cmaps')),
 
     preprocessHTML('web/viewer.html', defines)
-        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+      .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
     preprocessCSS('web/viewer.css', 'chrome', defines, true)
-        .pipe(postcss([autoprefixer({ browsers: ['chrome >= 49'], })]))
-        .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
+      .pipe(postcss([autoprefixer({ browsers: ['chrome >= 49'], })]))
+      .pipe(gulp.dest(CHROME_BUILD_CONTENT_DIR + 'web')),
 
     gulp.src('LICENSE').pipe(gulp.dest(CHROME_BUILD_DIR)),
     gulp.src('extensions/chromium/manifest.json')
-        .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))
-        .pipe(gulp.dest(CHROME_BUILD_DIR)),
+      .pipe(replace(/\bPDFJSSCRIPT_VERSION\b/g, version))
+      .pipe(gulp.dest(CHROME_BUILD_DIR)),
     gulp.src([
       'extensions/chromium/**/*.{html,js,css,png}',
       'extensions/chromium/preferences_schema.json'
     ], { base: 'extensions/chromium/', })
-        .pipe(gulp.dest(CHROME_BUILD_DIR)),
+      .pipe(gulp.dest(CHROME_BUILD_DIR)),
   ]);
-});
+}));
 
-gulp.task('chromium', ['chromium-pre']);
+gulp.task('chromium', gulp.series('chromium-pre'));
 
 gulp.task('jsdoc', function (done) {
   console.log();
@@ -883,13 +885,13 @@ gulp.task('jsdoc', function (done) {
   rimraf(JSDOC_BUILD_DIR, function () {
     mkdirp(JSDOC_BUILD_DIR, function () {
       var command = '"node_modules/.bin/jsdoc" -d ' + JSDOC_BUILD_DIR + ' ' +
-                    JSDOC_FILES.join(' ');
+        JSDOC_FILES.join(' ');
       exec(command, done);
     });
   });
 });
 
-gulp.task('lib', ['buildnumber'], function () {
+gulp.task('lib', gulp.series('buildnumber', function () {
   // When we create a bundle, webpack is run on the source and it will replace
   // require with __webpack_require__. When we want to use the real require,
   // __non_webpack_require__ has to be used.
@@ -969,11 +971,11 @@ gulp.task('lib', ['buildnumber'], function () {
     gulp.src('external/url/url-lib.js', { base: '.', })
       .pipe(gulp.dest('build/')),
   ]);
-});
+}));
 
-gulp.task('web-pre', ['generic', 'jsdoc']);
+gulp.task('web-pre', gulp.series('generic', 'jsdoc'));
 
-gulp.task('publish', ['generic'], function (done) {
+gulp.task('publish', gulp.series('generic', function (done) {
   var version = JSON.parse(
     fs.readFileSync(BUILD_DIR + 'version.json').toString()).version;
 
@@ -992,9 +994,9 @@ gulp.task('publish', ['generic'], function (done) {
           done();
         });
     });
-});
+}));
 
-gulp.task('mc-build', ['minified'], function(done) {
+gulp.task('mc-build', gulp.series('minified', function(done) {
   var targetName = getTargetName();
   gulp.src(BUILD_DIR + 'minified/**')
     .pipe(gulp.dest(MC_DIR))
@@ -1007,9 +1009,9 @@ gulp.task('mc-build', ['minified'], function(done) {
           done();
         });
     });
-});
+}));
 
-gulp.task('mc-deploy', ['mc-build'], function(done) {
+gulp.task('mc-deploy', gulp.series('mc-build', function(done) {
   var deployUrl = getDeployUrl();
   console.log('### Deploying ' + getTargetName() + ' to ' + deployUrl)
   gulp.src(BUILD_DIR + getTargetName())
@@ -1024,43 +1026,44 @@ gulp.task('mc-deploy', ['mc-build'], function(done) {
       console.log('### Please make sure to tag and push!');
       done();
     });
-});
+}));
 
-gulp.task('testing-pre', function() {
+gulp.task('testing-pre', function(done) {
   process.env['TESTING'] = 'true';
+  done();
 });
 
-gulp.task('test', ['testing-pre', 'generic', 'components'], function() {
+gulp.task('test', gulp.series('testing-pre', 'generic', 'components', function() {
   return streamqueue({ objectMode: true, },
     createTestSource('unit'), createTestSource('browser'));
-});
+}));
 
-gulp.task('bottest', ['testing-pre', 'generic', 'components'], function() {
+gulp.task('bottest', gulp.series('testing-pre', 'generic', 'components', function() {
   return streamqueue({ objectMode: true, },
     createTestSource('unit', true), createTestSource('font', true),
     createTestSource('browser (no reftest)', true));
-});
+}));
 
-gulp.task('browsertest', ['testing-pre', 'generic', 'components'], function() {
+gulp.task('browsertest', gulp.series('testing-pre', 'generic', 'components', function() {
   return createTestSource('browser');
-});
+}));
 
-gulp.task('unittest', ['testing-pre', 'generic', 'components'], function() {
+gulp.task('unittest', gulp.series('testing-pre', 'generic', 'components', function() {
   return createTestSource('unit');
-});
+}));
 
-gulp.task('fonttest', ['testing-pre'], function() {
+gulp.task('fonttest', gulp.series('testing-pre', function() {
   return createTestSource('font');
-});
+}));
 
-gulp.task('makeref', ['testing-pre', 'generic', 'components'], function(done) {
+gulp.task('makeref', gulp.series('testing-pre', 'generic', 'components', function(done) {
   makeRef(done);
-});
+}));
 
-gulp.task('botmakeref', ['testing-pre', 'generic', 'components'],
-    function(done) {
-  makeRef(done, true);
-});
+gulp.task('botmakeref', gulp.series('testing-pre', 'generic', 'components',
+  function(done) {
+    makeRef(done, true);
+  }));
 
 gulp.task('baseline', function (done) {
   console.log();
@@ -1086,22 +1089,22 @@ gulp.task('baseline', function (done) {
     }
 
     exec('git checkout ' + baselineCommit, { cwd: workingDirectory, },
-        function (error) {
-      if (error) {
-        done(new Error('Baseline commit checkout failed.'));
-        return;
-      }
+      function (error) {
+        if (error) {
+          done(new Error('Baseline commit checkout failed.'));
+          return;
+        }
 
-      console.log('Baseline commit "' + baselineCommit + '" checked out.');
-      done();
-    });
+        console.log('Baseline commit "' + baselineCommit + '" checked out.');
+        done();
+      });
   });
 });
 
-gulp.task('unittestcli', ['testing-pre', 'lib'], function(done) {
+gulp.task('unittestcli', gulp.series('testing-pre', 'lib', function(done) {
   var args = ['JASMINE_CONFIG_PATH=test/unit/clitests.json'];
   var testProcess = spawn('node_modules/.bin/jasmine', args,
-                          { stdio: 'inherit', });
+    { stdio: 'inherit', });
   testProcess.on('close', function (code) {
     if (code !== 0) {
       done(new Error('Unit tests failed.'));
@@ -1109,7 +1112,7 @@ gulp.task('unittestcli', ['testing-pre', 'lib'], function(done) {
     }
     done();
   });
-});
+}));
 
 gulp.task('lint', function (done) {
   console.log();
@@ -1117,7 +1120,7 @@ gulp.task('lint', function (done) {
 
   // Ensure that we lint the Firefox specific *.jsm files too.
   var options = ['node_modules/eslint/bin/eslint', '--ext', '.js,.jsm', '.',
-                 '--report-unused-disable-directives'];
+    '--report-unused-disable-directives'];
   var esLintProcess = spawn('node', options, { stdio: 'inherit', });
   esLintProcess.on('close', function (code) {
     if (code !== 0) {
@@ -1129,8 +1132,8 @@ gulp.task('lint', function (done) {
     console.log('### Checking supplemental files');
 
     if (!checkChromePreferencesFile(
-          'extensions/chromium/preferences_schema.json',
-          'web/default_preferences.json')) {
+      'extensions/chromium/preferences_schema.json',
+      'web/default_preferences.json')) {
       done(new Error('chromium/preferences_schema is not in sync.'));
       return;
     }
@@ -1181,7 +1184,7 @@ gulp.task('importl10n', function(done) {
   locales.downloadL10n(L10N_DIR, done);
 });
 
-gulp.task('gh-pages-prepare', ['web-pre'], function () {
+gulp.task('gh-pages-prepare', function () {
   console.log();
   console.log('### Creating web site');
 
@@ -1190,15 +1193,15 @@ gulp.task('gh-pages-prepare', ['web-pre'], function () {
   // 'vfs' because web/viewer.html needs its BOM.
   return merge([
     vfs.src(GENERIC_DIR + '**/*', { base: GENERIC_DIR, stripBOM: false, })
-       .pipe(gulp.dest(GH_PAGES_DIR)),
+      .pipe(gulp.dest(GH_PAGES_DIR)),
     gulp.src('test/features/**/*', { base: 'test/', })
-        .pipe(gulp.dest(GH_PAGES_DIR)),
+      .pipe(gulp.dest(GH_PAGES_DIR)),
     gulp.src(JSDOC_BUILD_DIR + '**/*', { base: JSDOC_BUILD_DIR, })
-        .pipe(gulp.dest(GH_PAGES_DIR + 'api/draft/')),
+      .pipe(gulp.dest(GH_PAGES_DIR + 'api/draft/')),
   ]);
 });
 
-gulp.task('wintersmith', ['gh-pages-prepare'], function (done) {
+gulp.task('wintersmith', function (done) {
   var wintersmith = require('wintersmith');
   var env = wintersmith('docs/config.json');
   env.build(GH_PAGES_DIR, function (error) {
@@ -1206,21 +1209,21 @@ gulp.task('wintersmith', ['gh-pages-prepare'], function (done) {
       return done(error);
     }
     replaceInFile(GH_PAGES_DIR + '/getting_started/index.html',
-                  /STABLE_VERSION/g, config.stableVersion);
+      /STABLE_VERSION/g, config.stableVersion);
     replaceInFile(GH_PAGES_DIR + '/getting_started/index.html',
-                  /BETA_VERSION/g, config.betaVersion);
+      /BETA_VERSION/g, config.betaVersion);
     console.log('Done building with wintersmith.');
     done();
   });
 });
 
-gulp.task('gh-pages-git', ['gh-pages-prepare', 'wintersmith'], function () {
+gulp.task('gh-pages-git', function (done) {
   var VERSION = getVersionJSON().version;
   var reason = process.env['PDFJS_UPDATE_REASON'];
 
   safeSpawnSync('git', ['init'], { cwd: GH_PAGES_DIR, });
   safeSpawnSync('git', ['remote', 'add', 'origin', REPO],
-                { cwd: GH_PAGES_DIR, });
+    { cwd: GH_PAGES_DIR, });
   safeSpawnSync('git', ['add', '-A'], { cwd: GH_PAGES_DIR, });
   safeSpawnSync('git', [
     'commit', '-am', 'gh-pages site created via gulpfile.js script',
@@ -1230,117 +1233,118 @@ gulp.task('gh-pages-git', ['gh-pages-prepare', 'wintersmith'], function () {
 
   console.log();
   console.log('Website built in ' + GH_PAGES_DIR);
+  done();
 });
 
-gulp.task('web', ['gh-pages-prepare', 'wintersmith', 'gh-pages-git']);
+gulp.task('web', gulp.series('gh-pages-prepare', 'wintersmith', 'gh-pages-git'));
 
 gulp.task('dist-pre',
-    ['generic', 'components', 'image_decoders', 'lib', 'minified'], function() {
-  var VERSION = getVersionJSON().version;
+  gulp.series('generic', 'components', 'image_decoders', 'lib', 'minified', function() {
+    var VERSION = getVersionJSON().version;
 
-  console.log();
-  console.log('### Cloning baseline distribution');
+    console.log();
+    console.log('### Cloning baseline distribution');
 
-  rimraf.sync(DIST_DIR);
-  mkdirp.sync(DIST_DIR);
-  safeSpawnSync('git', ['clone', '--depth', '1', DIST_REPO_URL, DIST_DIR]);
+    rimraf.sync(DIST_DIR);
+    mkdirp.sync(DIST_DIR);
+    safeSpawnSync('git', ['clone', '--depth', '1', DIST_REPO_URL, DIST_DIR]);
 
-  console.log();
-  console.log('### Overwriting all files');
-  rimraf.sync(path.join(DIST_DIR, '*'));
+    console.log();
+    console.log('### Overwriting all files');
+    rimraf.sync(path.join(DIST_DIR, '*'));
 
-  // Rebuilding manifests
-  var DIST_NAME = 'pdfjs-dist';
-  var DIST_DESCRIPTION = 'Generic build of Mozilla\'s PDF.js library.';
-  var DIST_KEYWORDS = ['Mozilla', 'pdf', 'pdf.js'];
-  var DIST_HOMEPAGE = 'http://mozilla.github.io/pdf.js/';
-  var DIST_BUGS_URL = 'https://github.com/mozilla/pdf.js/issues';
-  var DIST_LICENSE = 'Apache-2.0';
-  var npmManifest = {
-    name: DIST_NAME,
-    version: VERSION,
-    main: 'build/pdf.js',
-    description: DIST_DESCRIPTION,
-    keywords: DIST_KEYWORDS,
-    homepage: DIST_HOMEPAGE,
-    bugs: DIST_BUGS_URL,
-    license: DIST_LICENSE,
-    dependencies: {
-      'node-ensure': '^0.0.0', // shim for node for require.ensure
-      'worker-loader': '^2.0.0', // used in external/dist/webpack.json
-    },
-    peerDependencies: {
-      'webpack': '^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0', // from 'worker-loader'
-    },
-    browser: {
-      'fs': false,
-      'http': false,
-      'https': false,
-      'node-ensure': false,
-      'zlib': false,
-    },
-    format: 'amd', // to not allow system.js to choose 'cjs'
-    repository: {
-      type: 'git',
-      url: DIST_REPO_URL,
-    },
-  };
-  var packageJsonSrc =
-    createStringSource('package.json', JSON.stringify(npmManifest, null, 2));
-  var bowerManifest = {
-    name: DIST_NAME,
-    version: VERSION,
-    main: [
-      'build/pdf.js',
-      'build/pdf.worker.js',
-    ],
-    ignore: [],
-    keywords: DIST_KEYWORDS,
-  };
-  var bowerJsonSrc =
-    createStringSource('bower.json', JSON.stringify(bowerManifest, null, 2));
+    // Rebuilding manifests
+    var DIST_NAME = 'pdfjs-dist';
+    var DIST_DESCRIPTION = 'Generic build of Mozilla\'s PDF.js library.';
+    var DIST_KEYWORDS = ['Mozilla', 'pdf', 'pdf.js'];
+    var DIST_HOMEPAGE = 'http://mozilla.github.io/pdf.js/';
+    var DIST_BUGS_URL = 'https://github.com/mozilla/pdf.js/issues';
+    var DIST_LICENSE = 'Apache-2.0';
+    var npmManifest = {
+      name: DIST_NAME,
+      version: VERSION,
+      main: 'build/pdf.js',
+      description: DIST_DESCRIPTION,
+      keywords: DIST_KEYWORDS,
+      homepage: DIST_HOMEPAGE,
+      bugs: DIST_BUGS_URL,
+      license: DIST_LICENSE,
+      dependencies: {
+        'node-ensure': '^0.0.0', // shim for node for require.ensure
+        'worker-loader': '^2.0.0', // used in external/dist/webpack.json
+      },
+      peerDependencies: {
+        'webpack': '^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0', // from 'worker-loader'
+      },
+      browser: {
+        'fs': false,
+        'http': false,
+        'https': false,
+        'node-ensure': false,
+        'zlib': false,
+      },
+      format: 'amd', // to not allow system.js to choose 'cjs'
+      repository: {
+        type: 'git',
+        url: DIST_REPO_URL,
+      },
+    };
+    var packageJsonSrc =
+      createStringSource('package.json', JSON.stringify(npmManifest, null, 2));
+    var bowerManifest = {
+      name: DIST_NAME,
+      version: VERSION,
+      main: [
+        'build/pdf.js',
+        'build/pdf.worker.js',
+      ],
+      ignore: [],
+      keywords: DIST_KEYWORDS,
+    };
+    var bowerJsonSrc =
+      createStringSource('bower.json', JSON.stringify(bowerManifest, null, 2));
 
-  return merge([
-    gulp.src('external/streams/streams-lib.js', { base: '.', })
-      .pipe(gulp.dest('build/dist/')),
-    gulp.src('external/url/url-lib.js', { base: '.', })
-      .pipe(gulp.dest('build/dist/')),
-    packageJsonSrc.pipe(gulp.dest(DIST_DIR)),
-    bowerJsonSrc.pipe(gulp.dest(DIST_DIR)),
-    vfs.src('external/dist/**/*',
-            { base: 'external/dist', stripBOM: false, })
-       .pipe(gulp.dest(DIST_DIR)),
-    gulp.src(GENERIC_DIR + 'LICENSE')
+    return merge([
+      gulp.src('external/streams/streams-lib.js', { base: '.', })
+        .pipe(gulp.dest('build/dist/')),
+      gulp.src('external/url/url-lib.js', { base: '.', })
+        .pipe(gulp.dest('build/dist/')),
+      packageJsonSrc.pipe(gulp.dest(DIST_DIR)),
+      bowerJsonSrc.pipe(gulp.dest(DIST_DIR)),
+      vfs.src('external/dist/**/*',
+        { base: 'external/dist', stripBOM: false, })
         .pipe(gulp.dest(DIST_DIR)),
-    gulp.src(GENERIC_DIR + 'web/cmaps/**/*',
-             { base: GENERIC_DIR + 'web', })
+      gulp.src(GENERIC_DIR + 'LICENSE')
         .pipe(gulp.dest(DIST_DIR)),
-    gulp.src([
-      GENERIC_DIR + 'build/pdf.js',
-      GENERIC_DIR + 'build/pdf.js.map',
-      GENERIC_DIR + 'build/pdf.worker.js',
-      GENERIC_DIR + 'build/pdf.worker.js.map',
-      SRC_DIR + 'pdf.worker.entry.js',
-    ]).pipe(gulp.dest(DIST_DIR + 'build/')),
-    gulp.src(MINIFIED_DIR + 'build/pdf.js')
+      gulp.src(GENERIC_DIR + 'web/cmaps/**/*',
+        { base: GENERIC_DIR + 'web', })
+        .pipe(gulp.dest(DIST_DIR)),
+      gulp.src([
+        GENERIC_DIR + 'build/pdf.js',
+        GENERIC_DIR + 'build/pdf.js.map',
+        GENERIC_DIR + 'build/pdf.worker.js',
+        GENERIC_DIR + 'build/pdf.worker.js.map',
+        SRC_DIR + 'pdf.worker.entry.js',
+      ]).pipe(gulp.dest(DIST_DIR + 'build/')),
+      gulp.src(MINIFIED_DIR + 'build/pdf.js')
         .pipe(rename('pdf.min.js'))
         .pipe(gulp.dest(DIST_DIR + 'build/')),
-    gulp.src(MINIFIED_DIR + 'build/pdf.worker.js')
+      gulp.src(MINIFIED_DIR + 'build/pdf.worker.js')
         .pipe(rename('pdf.worker.min.js'))
         .pipe(gulp.dest(DIST_DIR + 'build/')),
-    gulp.src(MINIFIED_DIR + 'image_decoders/pdf.image_decoders.js')
+      gulp.src(MINIFIED_DIR + 'image_decoders/pdf.image_decoders.js')
         .pipe(rename('pdf.image_decoders.min.js'))
         .pipe(gulp.dest(DIST_DIR + 'image_decoders/')),
-    gulp.src(COMPONENTS_DIR + '**/*', { base: COMPONENTS_DIR, })
+      gulp.src(COMPONENTS_DIR + '**/*', { base: COMPONENTS_DIR, })
         .pipe(gulp.dest(DIST_DIR + 'web/')),
-    gulp.src(IMAGE_DECODERS_DIR + '**/*', { base: IMAGE_DECODERS_DIR, })
+      gulp.src(IMAGE_DECODERS_DIR + '**/*', { base: IMAGE_DECODERS_DIR, })
         .pipe(gulp.dest(DIST_DIR + 'image_decoders')),
-    gulp.src(LIB_DIR + '**/*', { base: LIB_DIR, })
+      gulp.src(LIB_DIR + '**/*', { base: LIB_DIR, })
         .pipe(gulp.dest(DIST_DIR + 'lib/')),
-  ]);
-});
+    ]);
+  }));
 
-gulp.task('dist-install', ['dist-pre'], function () {
+gulp.task('dist-install', gulp.series('dist-pre', function () {
   var distPath = DIST_DIR;
   var opts = {};
   var installPath = process.env['PDFJS_INSTALL_PATH'];
@@ -1349,9 +1353,9 @@ gulp.task('dist-install', ['dist-pre'], function () {
     distPath = path.relative(installPath, distPath);
   }
   safeSpawnSync('npm', ['install', distPath], opts);
-});
+}));
 
-gulp.task('dist-repo-git', ['dist-pre'], function () {
+gulp.task('dist-repo-git', gulp.series('dist-pre', function () {
   var VERSION = getVersionJSON().version;
 
   console.log();
@@ -1362,18 +1366,18 @@ gulp.task('dist-repo-git', ['dist-pre'], function () {
   safeSpawnSync('git', ['add', '*'], { cwd: DIST_DIR, });
   safeSpawnSync('git', ['commit', '-am', message], { cwd: DIST_DIR, });
   safeSpawnSync('git', ['tag', '-a', 'v' + VERSION, '-m', message],
-                { cwd: DIST_DIR, });
+    { cwd: DIST_DIR, });
 
   console.log();
   console.log('Done. Push with');
   console.log('  cd ' + DIST_DIR + '; ' +
-              'git push --tags ' + DIST_REPO_URL + ' master');
+    'git push --tags ' + DIST_REPO_URL + ' master');
   console.log();
-});
+}));
 
-gulp.task('dist', ['dist-repo-git']);
+gulp.task('dist', gulp.series('dist-repo-git'));
 
-gulp.task('mozcentralbaseline', ['baseline'], function (done) {
+gulp.task('mozcentralbaseline', gulp.series('baseline', function (done) {
   console.log();
   console.log('### Creating mozcentral baseline environment');
 
@@ -1382,37 +1386,37 @@ gulp.task('mozcentralbaseline', ['baseline'], function (done) {
 
   var workingDirectory = path.resolve(process.cwd(), BASELINE_DIR);
   safeSpawnSync('gulp', ['mozcentral'],
-                { env: process.env, cwd: workingDirectory, stdio: 'inherit', });
+    { env: process.env, cwd: workingDirectory, stdio: 'inherit', });
 
   // Copy the mozcentral build to the mozcentral baseline directory.
   rimraf.sync(MOZCENTRAL_BASELINE_DIR);
   mkdirp.sync(MOZCENTRAL_BASELINE_DIR);
 
   gulp.src([BASELINE_DIR + BUILD_DIR + 'mozcentral/**/*'])
-      .pipe(gulp.dest(MOZCENTRAL_BASELINE_DIR))
-      .on('end', function () {
-        // Commit the mozcentral baseline.
-        safeSpawnSync('git', ['init'], { cwd: MOZCENTRAL_BASELINE_DIR, });
-        safeSpawnSync('git', ['add', '.'], { cwd: MOZCENTRAL_BASELINE_DIR, });
-        safeSpawnSync('git', ['commit', '-m', '"mozcentral baseline"'],
-                      { cwd: MOZCENTRAL_BASELINE_DIR, });
-        done();
-      });
-});
+    .pipe(gulp.dest(MOZCENTRAL_BASELINE_DIR))
+    .on('end', function () {
+      // Commit the mozcentral baseline.
+      safeSpawnSync('git', ['init'], { cwd: MOZCENTRAL_BASELINE_DIR, });
+      safeSpawnSync('git', ['add', '.'], { cwd: MOZCENTRAL_BASELINE_DIR, });
+      safeSpawnSync('git', ['commit', '-m', '"mozcentral baseline"'],
+        { cwd: MOZCENTRAL_BASELINE_DIR, });
+      done();
+    });
+}));
 
-gulp.task('mozcentraldiff', ['mozcentral', 'mozcentralbaseline'],
-    function (done) {
-  console.log();
-  console.log('### Creating mozcentral diff');
+gulp.task('mozcentraldiff', gulp.series('mozcentral', 'mozcentralbaseline',
+  function (done) {
+    console.log();
+    console.log('### Creating mozcentral diff');
 
-  // Create the diff between the current mozcentral build and the
-  // baseline mozcentral build, which both exist at this point.
-  // The mozcentral baseline directory is a Git repository, so we
-  // remove all files and copy the current mozcentral build files
-  // into it to create the diff.
-  rimraf.sync(MOZCENTRAL_BASELINE_DIR + '*');
+    // Create the diff between the current mozcentral build and the
+    // baseline mozcentral build, which both exist at this point.
+    // The mozcentral baseline directory is a Git repository, so we
+    // remove all files and copy the current mozcentral build files
+    // into it to create the diff.
+    rimraf.sync(MOZCENTRAL_BASELINE_DIR + '*');
 
-  gulp.src([BUILD_DIR + 'mozcentral/**/*'])
+    gulp.src([BUILD_DIR + 'mozcentral/**/*'])
       .pipe(gulp.dest(MOZCENTRAL_BASELINE_DIR))
       .on('end', function () {
         safeSpawnSync('git', ['add', '-A'], { cwd: MOZCENTRAL_BASELINE_DIR, });
@@ -1424,17 +1428,18 @@ gulp.task('mozcentraldiff', ['mozcentral', 'mozcentralbaseline'],
           .pipe(gulp.dest(BUILD_DIR))
           .on('end', function () {
             console.log('Result diff can be found at ' + BUILD_DIR +
-                        MOZCENTRAL_DIFF_FILE);
+              MOZCENTRAL_DIFF_FILE);
             done();
           });
       });
-});
+  }));
 
-gulp.task('externaltest', function () {
+gulp.task('externaltest', function (done) {
   fancylog('Running test-fixtures.js');
   safeSpawnSync('node', ['external/builder/test-fixtures.js'],
-                { stdio: 'inherit', });
+    { stdio: 'inherit', });
   fancylog('Running test-fixtures_esprima.js');
   safeSpawnSync('node', ['external/builder/test-fixtures_esprima.js'],
-                { stdio: 'inherit', });
+    { stdio: 'inherit', });
+  done();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,11 +477,29 @@
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
+    "arr-filter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
+    },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
+    },
+    "arr-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "dev": true,
+      "requires": {
+        "make-iterator": "^1.0.0"
+      }
     },
     "arr-union": {
       "version": "3.1.0",
@@ -501,11 +519,65 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
+    "array-initial": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "dev": true,
+      "requires": {
+        "array-slice": "^1.0.0",
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "array-last": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
     "array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
+    },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
+      "requires": {
+        "default-compare": "^1.0.0",
+        "get-value": "^2.0.6",
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -587,11 +659,40 @@
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
       "dev": true
     },
+    "async-done": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
+      "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.2",
+        "process-nextick-args": "^1.0.7",
+        "stream-exhaust": "^1.0.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        }
+      }
+    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "async-settle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "dev": true,
+      "requires": {
+        "async-done": "^1.2.2"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1326,6 +1427,23 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
+    "bach": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "dev": true,
+      "requires": {
+        "arr-filter": "^1.1.1",
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "array-each": "^1.0.0",
+        "array-initial": "^1.0.0",
+        "array-last": "^1.1.1",
+        "async-done": "^1.2.2",
+        "async-settle": "^1.0.0",
+        "now-and-later": "^2.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1922,6 +2040,17 @@
       "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
       "dev": true
     },
+    "collection-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "dev": true,
+      "requires": {
+        "arr-map": "^2.0.2",
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2059,6 +2188,16 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "copy-props": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+      "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+      "dev": true,
+      "requires": {
+        "each-props": "^1.3.0",
+        "is-plain-object": "^2.0.1"
+      }
     },
     "core-js": {
       "version": "2.5.7",
@@ -2231,14 +2370,28 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "kind-of": "^5.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
       }
+    },
+    "default-resolution": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.2",
@@ -2318,12 +2471,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "deprecated": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
       "dev": true
     },
     "des.js": {
@@ -2487,6 +2634,16 @@
         }
       }
     },
+    "each-props": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+      "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.1",
+        "object.defaults": "^1.1.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2531,23 +2688,12 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "~1.3.0"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        }
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -3256,12 +3402,6 @@
         "pkg-dir": "^2.0.0"
       }
     },
-    "find-index": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-      "dev": true
-    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -3272,21 +3412,32 @@
       }
     },
     "findup-sync": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "dev": true,
       "requires": {
         "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
+        "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
       }
     },
     "fined": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
       "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
@@ -3296,16 +3447,10 @@
         "parse-filepath": "^1.0.1"
       }
     },
-    "first-chunk-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-      "dev": true
-    },
     "flagged-respawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
       "dev": true
     },
     "flat-cache": {
@@ -3435,7 +3580,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3456,12 +3602,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3476,17 +3624,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3603,7 +3754,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3615,6 +3767,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3629,6 +3782,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3636,12 +3790,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3660,6 +3816,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3740,7 +3897,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3752,6 +3910,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3837,7 +3996,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3873,6 +4033,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3892,6 +4053,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3935,12 +4097,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3955,15 +4119,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "gaze": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true,
-      "requires": {
-        "globule": "~0.1.0"
-      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -4052,93 +4207,18 @@
         "path-dirname": "^1.0.0"
       }
     },
-    "glob-stream": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-      "dev": true,
-      "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
     "glob-watcher": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.3.tgz",
+      "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
-      }
-    },
-    "glob2base": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true,
-      "requires": {
-        "find-index": "^0.1.1"
+        "anymatch": "^2.0.0",
+        "async-done": "^1.2.0",
+        "chokidar": "^2.0.0",
+        "is-negated-glob": "^1.0.0",
+        "just-debounce": "^1.0.0",
+        "object.defaults": "^1.1.0"
       }
     },
     "global-modules": {
@@ -4193,64 +4273,6 @@
         }
       }
     },
-    "globule": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-      "dev": true,
-      "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
-          }
-        },
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
-      }
-    },
     "glogg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
@@ -4273,136 +4295,199 @@
       "dev": true
     },
     "gulp": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+      "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "glob-watcher": "^5.0.3",
+        "gulp-cli": "^2.2.0",
+        "undertaker": "^1.2.1",
+        "vinyl-fs": "^3.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+        "gulp-cli": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+          "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "ansi-colors": "^1.0.1",
+            "archy": "^1.0.0",
+            "array-sort": "^1.0.0",
+            "color-support": "^1.1.3",
+            "concat-stream": "^1.6.0",
+            "copy-props": "^2.0.1",
+            "fancy-log": "^1.3.2",
+            "gulplog": "^1.0.0",
+            "interpret": "^1.1.0",
+            "isobject": "^3.0.1",
+            "liftoff": "^3.1.0",
+            "matchdep": "^2.0.0",
+            "mute-stdout": "^1.0.0",
+            "pretty-hrtime": "^1.0.0",
+            "replace-homedir": "^1.0.0",
+            "semver-greatest-satisfied-range": "^1.1.0",
+            "v8flags": "^3.0.1",
+            "yargs": "^7.1.0"
           }
         },
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "number-is-nan": "^1.0.0"
           }
         },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
-        "vinyl-fs": {
-          "version": "0.3.14",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-          "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "defaults": "^1.0.0",
-            "glob-stream": "^3.1.5",
-            "glob-watcher": "^0.0.6",
-            "graceful-fs": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "strip-bom": "^1.0.0",
-            "through2": "^0.6.1",
-            "vinyl": "^0.4.0"
+            "lcid": "^1.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -4742,9 +4827,9 @@
       }
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -5493,6 +5578,12 @@
         "markdown": "^0.5.0"
       }
     },
+    "just-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+      "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+      "dev": true
+    },
     "keypress": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
@@ -5512,6 +5603,16 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "last-run": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+      "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+      "dev": true,
+      "requires": {
+        "default-resolution": "^2.0.0",
+        "es6-weak-map": "^2.0.1"
       }
     },
     "lazy-cache": {
@@ -5558,13 +5659,13 @@
       }
     },
     "liftoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+      "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
       "dev": true,
       "requires": {
         "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
+        "findup-sync": "^3.0.0",
         "fined": "^1.0.1",
         "flagged-respawn": "^1.0.0",
         "is-plain-object": "^2.0.4",
@@ -5872,6 +5973,32 @@
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
+    "matchdep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+      "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "^2.0.0",
+        "micromatch": "^3.0.4",
+        "resolve": "^1.4.0",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        }
+      }
+    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -6095,6 +6222,12 @@
         "duplexer2": "0.0.2"
       }
     },
+    "mute-stdout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
+      "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -6127,12 +6260,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
-    },
-    "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
-      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -11679,6 +11806,16 @@
         "isobject": "^3.0.1"
       }
     },
+    "object.reduce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+      "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11710,23 +11847,6 @@
         "type-check": "~0.3.2",
         "wordwrap": "~1.0.0"
       }
-    },
-    "orchestrator": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
-      }
-    },
-    "ordered-read-streams": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-      "dev": true
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -11915,9 +12035,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-root": {
@@ -12489,6 +12609,17 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
+    "replace-homedir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+      "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1",
+        "is-absolute": "^1.0.0",
+        "remove-trailing-separator": "^1.1.0"
+      }
+    },
     "replacestream": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
@@ -12582,12 +12713,12 @@
       }
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-dir": {
@@ -12735,11 +12866,14 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
-    "sequencify": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-      "dev": true
+    "semver-greatest-satisfied-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+      "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
+      "requires": {
+        "sver-compat": "^1.5.0"
+      }
     },
     "serialize-javascript": {
       "version": "1.5.0",
@@ -12817,12 +12951,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
@@ -13129,12 +13257,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
-      "dev": true
-    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -13155,6 +13277,12 @@
           }
         }
       }
+    },
+    "stream-exhaust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
+      "dev": true
     },
     "stream-http": {
       "version": "2.8.2",
@@ -13237,12 +13365,11 @@
       }
     },
     "strip-bom": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
         "is-utf8": "^0.2.0"
       }
     },
@@ -13271,6 +13398,16 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "sver-compat": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+      "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "systemjs": {
@@ -13345,15 +13482,6 @@
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
-      }
-    },
-    "tildify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
       }
     },
     "time-stamp": {
@@ -13619,6 +13747,29 @@
         }
       }
     },
+    "undertaker": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+      "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1",
+        "arr-map": "^2.0.0",
+        "bach": "^1.0.0",
+        "collection-map": "^1.0.0",
+        "es6-weak-map": "^2.0.1",
+        "last-run": "^1.1.0",
+        "object.defaults": "^1.0.0",
+        "object.reduce": "^1.0.0",
+        "undertaker-registry": "^1.0.0"
+      }
+    },
+    "undertaker-registry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+      "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -13671,12 +13822,6 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
-    },
-    "unique-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -13766,12 +13911,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
-    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -13802,12 +13941,12 @@
       "dev": true
     },
     "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "valid-url": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "eslint-plugin-unicorn": "^4.0.3",
     "fancy-log": "^1.3.2",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "gulp-artifactory-upload": "^1.3.0",
     "gulp-postcss": "^7.0.1",
     "gulp-rename": "^1.4.0",


### PR DESCRIPTION
The changes in this branch are to upgrade gulp to version 4.0.0.

We decided to upgrade gulp because gulp tasks would fail if you were running node v10+. 
This issue is explained here: [https://github.com/mozilla/pdf.js/issues/10355](url)