### PR TITLE
QX-5050 Readonly Form fields Version2023.3

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,9 +77,9 @@ const MOZCENTRAL_DIFF_FILE = "mozcentral.diff";
 const REPO = "git@github.com:mozilla/pdf.js.git";
 const DIST_REPO_URL = "https://github.com/mozilla/pdfjs-dist";
 const ARTIFACTORY_RELEASE_REPO_URL =
-    "https://mastercontrol.jfrog.io/artifactory/libs-release-local/";
+  "https://mastercontrol.jfrog.io/artifactory/libs-release-local/";
 const ARTIFACTORY_SNAPSHOT_REPO_URL =
-    "https://mastercontrol.jfrog.io/artifactory/libs-snapshot-local/";
+  "https://mastercontrol.jfrog.io/artifactory/libs-snapshot-local/";
 const builder = require("./external/builder/builder.js");
 
 const CONFIG_FILE = "pdfjs.config";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,9 +77,9 @@ const MOZCENTRAL_DIFF_FILE = "mozcentral.diff";
 const REPO = "git@github.com:mozilla/pdf.js.git";
 const DIST_REPO_URL = "https://github.com/mozilla/pdfjs-dist";
 const ARTIFACTORY_RELEASE_REPO_URL =
-  "https://labs.mastercontrol.com/artifactory/libs-release-local/";
+    "https://mastercontrol.jfrog.io/artifactory/libs-release-local/";
 const ARTIFACTORY_SNAPSHOT_REPO_URL =
-  "https://labs.mastercontrol.com/artifactory/libs-snapshot-local/";
+    "https://mastercontrol.jfrog.io/artifactory/libs-snapshot-local/";
 const builder = require("./external/builder/builder.js");
 
 const CONFIG_FILE = "pdfjs.config";
@@ -1782,8 +1782,8 @@ function mcDeploy(deployUrl, done) {
     .pipe(
       artifactoryUpload({
         url: deployUrl,
-        username: process.env.artifactory_username,
-        password: process.env.artifactory_password,
+        username: process.env.mc_artifactory_user,
+        password: process.env.mc_artifactory_api_key,
       })
     )
     .on("error", console.log)

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1582,7 +1582,7 @@ class WidgetAnnotation extends Annotation {
       data.fieldFlags = 0;
     }
 
-    data.readOnly = true;
+    data.readOnly = this.hasFieldFlag(AnnotationFieldFlag.READONLY);
     data.required = this.hasFieldFlag(AnnotationFieldFlag.REQUIRED);
     data.hidden = this._hasFlag(data.annotationFlags, AnnotationFlag.HIDDEN);
   }

--- a/src/core/annotation.js
+++ b/src/core/annotation.js
@@ -1582,7 +1582,7 @@ class WidgetAnnotation extends Annotation {
       data.fieldFlags = 0;
     }
 
-    data.readOnly = this.hasFieldFlag(AnnotationFieldFlag.READONLY);
+    data.readOnly = true;
     data.required = this.hasFieldFlag(AnnotationFieldFlag.REQUIRED);
     data.hidden = this._hasFlag(data.annotationFlags, AnnotationFlag.HIDDEN);
   }

--- a/web/app_options.js
+++ b/web/app_options.js
@@ -60,7 +60,7 @@ const defaultOptions = {
   },
   annotationMode: {
     /** @type {number} */
-    value: 2,
+    value: 1,
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE,
   },
   cursorToolOnLoad: {


### PR DESCRIPTION
We want our inline pdf viewer to be for viewing and not for editing. Right now customers could have coversheets that have editable form fields, which we don't want to appear editable in the viewer (when the pdf is downloaded the JS in the overlay makes them all readonly, but we remove the overlay JS for the viewer).

Ideally in this PR we can find an elegant solution to disallow a user from editing form fields in the viewer if they exist. I'm hoping to use something like a preference option, but falling back to some hard coded solution may have to do.